### PR TITLE
Delta from upstream

### DIFF
--- a/content_scripts/vimium.css
+++ b/content_scripts/vimium.css
@@ -79,7 +79,8 @@ div.internalVimiumHintMarker {
   white-space: nowrap;
   overflow: hidden;
   font-size: 11px;
-  padding: 2px 4px 2px 4px;
+  /* padding: 2px 4px 2px 4px; */
+  padding: 1px 2px 0px 2px;
   background: white; 
   border-radius: 2px;
   box-shadow: 0 0 0px 1px #fff, 0 1px 2px 2px #c0f, 0 2px 1px 2px #0af;
@@ -89,10 +90,11 @@ div.internalVimiumHintMarker {
 
 div.internalVimiumHintMarker span {
   color: black;
-  font-family: "Source Code Pro", ui-monospace, monospace, sans-serif;
+  /* font-family: "Source Code Pro", ui-monospace, monospace, sans-serif; */
   font-weight: bold;
+  /* font-size: 12px; */
   font-size: 11px;
-  text-transform: lowercase;
+  /* text-transform: lowercase; */
 }
 
 .dark div.internalVimiumHintMarker,

--- a/content_scripts/vimium.css
+++ b/content_scripts/vimium.css
@@ -79,19 +79,41 @@ div.internalVimiumHintMarker {
   white-space: nowrap;
   overflow: hidden;
   font-size: 11px;
-  padding: 1px 3px 0px 3px;
-  background: linear-gradient(to bottom, #FFF785 0%,#FFC542 100%);
-  border: solid 1px #C38A22;
-  border-radius: 3px;
-  box-shadow: 0px 3px 7px 0px rgba(0, 0, 0, 0.3);
+  padding: 2px 4px 2px 4px;
+  background: white; 
+  border-radius: 2px;
+  box-shadow: 0 0 0px 1px #fff, 0 1px 2px 2px #c0f, 0 2px 1px 2px #0af;
 }
 
+
+
 div.internalVimiumHintMarker span {
-  color: #302505;
-  font-family: Helvetica, Arial, sans-serif;
+  color: black;
+  font-family: "Source Code Pro", ui-monospace, monospace, sans-serif;
   font-weight: bold;
   font-size: 11px;
-  text-shadow: 0 1px 0 rgba(255, 255, 255, 0.6);
+  text-transform: lowercase;
+}
+
+.dark div.internalVimiumHintMarker,
+.dark-mode div.internalVimiumHintMarker,
+.darkmode div.internalVimiumHintMarker,
+.theme-dark div.internalVimiumHintMarker,
+.dark-theme div.internalVimiumHintMarker,
+.darktheme div.internalVimiumHintMarker
+{
+  background: #222;
+  box-shadow: 0 0 0px 1px #111, 0 1px 2px 2px #c0f, 0 2px 1px 2px #0af;
+}
+
+.dark div.internalVimiumHintMarker span,
+.dark-mode div.internalVimiumHintMarker span,
+.darkmode div.internalVimiumHintMarker span,
+.theme-dark div.internalVimiumHintMarker span,
+.dark-theme div.internalVimiumHintMarker span,
+.darktheme div.internalVimiumHintMarker span
+{
+  color: white;
 }
 
 div.internalVimiumHintMarker > .matchingCharacter {

--- a/content_scripts/vimium.css
+++ b/content_scripts/vimium.css
@@ -102,8 +102,7 @@ div.internalVimiumHintMarker span {
 .darkmode div.internalVimiumHintMarker,
 .theme-dark div.internalVimiumHintMarker,
 .dark-theme div.internalVimiumHintMarker,
-.darktheme div.internalVimiumHintMarker
-{
+.darktheme div.internalVimiumHintMarker {
   background: #222;
   box-shadow: 0 0 0px 1px #111, 0 1px 2px 2px #c0f, 0 2px 1px 2px #0af;
 }
@@ -113,8 +112,7 @@ div.internalVimiumHintMarker span {
 .darkmode div.internalVimiumHintMarker span,
 .theme-dark div.internalVimiumHintMarker span,
 .dark-theme div.internalVimiumHintMarker span,
-.darktheme div.internalVimiumHintMarker span
-{
+.darktheme div.internalVimiumHintMarker span {
   color: white;
 }
 

--- a/manifest.json
+++ b/manifest.json
@@ -7,6 +7,11 @@
               "48": "icons/icon48.png",
              "128": "icons/icon128.png" },
   "minimum_chrome_version": "69.0",
+  "applications": {
+    "gecko": {
+      "id": "nvp-permissionless@vimium.net"
+    }
+  },
   "background": {
     "scripts": [
       "lib/utils.js",
@@ -26,7 +31,10 @@
     "chrome_style": false,
     "open_in_tab": true
   },
-  "permissions": [],
+  "permissions": [
+    "storage",
+    "webNavigation"
+  ],
   "content_scripts": [
     {
       "matches": ["<all_urls>"],

--- a/manifest.json
+++ b/manifest.json
@@ -26,16 +26,7 @@
     "chrome_style": false,
     "open_in_tab": true
   },
-  "permissions": [
-    "tabs",
-    "bookmarks",
-    "history",
-    "storage",
-    "sessions",
-    "notifications",
-    "webNavigation",
-    "<all_urls>"
-  ],
+  "permissions": [],
   "content_scripts": [
     {
       "matches": ["<all_urls>"],


### PR DESCRIPTION
Easy diff for folks to see what I've changed from the official vimium https://github.com/philc/vimium

My use case is more specific than what all vimium offers, and I don't like giving permissions to things that don't need them.


To use this branch of vimium:
1. clone locally
2. switch to the `permissionless-mode` branch
3. follow the instructions for [installing from source](https://github.com/NullVoxPopuli/vimium/blob/master/CONTRIBUTING.md#installing-from-source)


A note on "permissionless" -- without altering any code, in order to use `f`-navigation:
 - the `storage` permission is needed because vimium uses local storage to define "secrets" between windows so that the extension can communicate with the page being viewed (event listeners, ui decoration, etc)
 - `webNavigation` - used to check if vimium is enabled for a frame / when the URL changes without a reload